### PR TITLE
Upload Scryfall images to Notion

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,13 +15,13 @@ st.set_page_config(page_title="MTG Notion Importer", page_icon="🗂️", layout
 st.title("MTG – Notion Importer (Shared DB)")
 st.caption("UPSERT into one shared database. Existing pages: minimal update (Title, Procurement, Oracle/FF names, CN Sort). New pages: full create.")
 
-def props_create(rec: Dict[str, Any], title_prop: str, title_text: str) -> Dict[str, Any]:
+def props_create(notion: NotionClient, rec: Dict[str, Any], title_prop: str, title_text: str) -> Dict[str, Any]:
     def rt(v): return {"rich_text":[{"type":"text","text":{"content":v}}]} if v else {"rich_text":[]}
     def sel(v): return {"select":{"name":v}} if v else {"select":None}
     def ms(vs): return {"multi_select":[{"name":x} for x in (vs or [])]}
     def num(n): return {"number": float(n) if n is not None else None}
     def url(v): return {"url": v or None}
-    files = [{"type":"external","name":"image","external":{"url":u}} for u in (rec.get("image_urls") or [])]
+    files = notion.upload_images(rec.get("image_urls"))
     return {
         title_prop: {"title":[{"type":"text","text":{"content": title_text}}]},
         "Set": sel(rec.get("set")),
@@ -45,16 +45,18 @@ def props_create(rec: Dict[str, Any], title_prop: str, title_text: str) -> Dict[
         "Image": {"files": files},
     }
 
-def props_update(title_prop: str, title_text: str, rec: Dict[str, Any]) -> Dict[str, Any]:
+def props_update(notion: NotionClient, title_prop: str, title_text: str, rec: Dict[str, Any]) -> Dict[str, Any]:
     def ms(vs): return {"multi_select":[{"name":x} for x in (vs or [])]}
     def rt(v): return {"rich_text":[{"type":"text","text":{"content":v}}]} if v else {"rich_text":[]}
     def num(n): return {"number": float(n) if n is not None else None}
+    files = notion.upload_images(rec.get("image_urls"))
     return {
         title_prop: {"title":[{"type":"text","text":{"content": title_text}}]},
         "Procurement Method": ms(rec.get("procurement") or []),
         "Oracle Name": rt(rec.get("oracle_raw","")),
         "FF Name": rt(rec.get("ff_raw","")),
         "CN Sort": num(rec.get("cn_sort")),
+        "Image": {"files": files},
     }
 
 def ensure_db(notion: NotionClient, parent_id: str, title: str):
@@ -116,14 +118,14 @@ with tab:
                         existing = notion.query_by_card_id(db["id"], rec["id"])
                         if existing:
                             if update_existing:
-                                notion.update_card_minimal(existing["id"], props_update(title_prop, new_title, rec))
+                                notion.update_card_minimal(existing["id"], props_update(notion, title_prop, new_title, rec))
                                 updated += 1
                                 if len(sample) < 10:
                                     sample.append(f'{u}-{rec.get("collector_number","?")}: → {new_title}')
                             else:
                                 skipped += 1
                         else:
-                            notion.create_card_page(db["id"], props_create(rec, title_prop, new_title))
+                            notion.create_card_page(db["id"], props_create(notion, rec, title_prop, new_title))
                             created += 1
                     except Exception as e:
                         failed += 1

--- a/cli.py
+++ b/cli.py
@@ -7,13 +7,13 @@ from .overrides import load_overrides, apply_overrides
 
 def _ts(): return time.strftime("[%Y-%m-%d %H:%M:%S]")
 
-def build_props_for_create(rec: dict, title_prop: str, title_text: str) -> Dict[str, Any]:
+def build_props_for_create(rec: dict, title_prop: str, title_text: str, notion: NotionClient) -> Dict[str, Any]:
     def rt(v): return {"rich_text":[{"type":"text","text":{"content":v}}]} if v else {"rich_text":[]}
     def sel(v): return {"select":{"name":v}} if v else {"select":None}
     def ms(vs): return {"multi_select":[{"name":x} for x in (vs or [])]}
     def num(n): return {"number": float(n) if n is not None else None}
     def url(v): return {"url": v or None}
-    files = [{"type":"external","name":"image","external":{"url":u}} for u in (rec.get("image_urls") or [])]
+    files = notion.upload_images(rec.get("image_urls"))
     return {
         title_prop: {"title":[{"type":"text","text":{"content": title_text}}]},
         "Set": sel(rec.get("set")),
@@ -37,16 +37,18 @@ def build_props_for_create(rec: dict, title_prop: str, title_text: str) -> Dict[
         "Image": {"files": files},
     }
 
-def build_props_for_update(title_prop: str, title_text: str, rec: dict) -> Dict[str, Any]:
+def build_props_for_update(title_prop: str, title_text: str, rec: dict, notion: NotionClient) -> Dict[str, Any]:
     def ms(vs): return {"multi_select":[{"name":x} for x in (vs or [])]}
     def rt(v): return {"rich_text":[{"type":"text","text":{"content":v}}]} if v else {"rich_text":[]}
     def num(n): return {"number": float(n) if n is not None else None}
+    files = notion.upload_images(rec.get("image_urls"))
     return {
         title_prop: {"title":[{"type":"text","text":{"content": title_text}}]},
         "Procurement Method": ms(rec.get("procurement") or []),
         "Oracle Name": rt(rec.get("oracle_raw","")),
         "FF Name": rt(rec.get("ff_raw","")),
         "CN Sort": num(rec.get("cn_sort")),
+        "Image": {"files": files},
     }
 
 def cmd_import(args):
@@ -91,7 +93,7 @@ def cmd_import(args):
                             previews.append(f'UPDATE {key}: "{title_text}" | methods={rec.get("procurement")}')
                         updated += 1
                     else:
-                        props = build_props_for_update(title_prop, title_text, rec)
+                        props = build_props_for_update(title_prop, title_text, rec, notion)
                         notion.update_card_minimal(existing["id"], props)
                         updated += 1
                 else:
@@ -100,7 +102,7 @@ def cmd_import(args):
                             previews.append(f'CREATE {key}: "{title_text}" | methods={rec.get("procurement")}')
                         created += 1
                     else:
-                        props = build_props_for_create(rec, title_prop, title_text)
+                        props = build_props_for_create(rec, title_prop, title_text, notion)
                         notion.create_card_page(db["id"], props)
                         created += 1
             except Exception as e:

--- a/mtg_importer/app.py
+++ b/mtg_importer/app.py
@@ -15,13 +15,13 @@ st.set_page_config(page_title="MTG Notion Importer", page_icon="🗂️", layout
 st.title("MTG – Notion Importer (Shared DB)")
 st.caption("UPSERT into one shared database. Existing pages: minimal update (Title, Procurement, Oracle/FF names, CN Sort). New pages: full create.")
 
-def props_create(rec: Dict[str, Any], title_prop: str, title_text: str) -> Dict[str, Any]:
+def props_create(notion: NotionClient, rec: Dict[str, Any], title_prop: str, title_text: str) -> Dict[str, Any]:
     def rt(v): return {"rich_text":[{"type":"text","text":{"content":v}}]} if v else {"rich_text":[]}
     def sel(v): return {"select":{"name":v}} if v else {"select":None}
     def ms(vs): return {"multi_select":[{"name":x} for x in (vs or [])]}
     def num(n): return {"number": float(n) if n is not None else None}
     def url(v): return {"url": v or None}
-    files = [{"type":"external","name":"image","external":{"url":u}} for u in (rec.get("image_urls") or [])]
+    files = notion.upload_images(rec.get("image_urls"))
     return {
         title_prop: {"title":[{"type":"text","text":{"content": title_text}}]},
         "Set": sel(rec.get("set")),
@@ -45,16 +45,18 @@ def props_create(rec: Dict[str, Any], title_prop: str, title_text: str) -> Dict[
         "Image": {"files": files},
     }
 
-def props_update(title_prop: str, title_text: str, rec: Dict[str, Any]) -> Dict[str, Any]:
+def props_update(notion: NotionClient, title_prop: str, title_text: str, rec: Dict[str, Any]) -> Dict[str, Any]:
     def ms(vs): return {"multi_select":[{"name":x} for x in (vs or [])]}
     def rt(v): return {"rich_text":[{"type":"text","text":{"content":v}}]} if v else {"rich_text":[]}
     def num(n): return {"number": float(n) if n is not None else None}
+    files = notion.upload_images(rec.get("image_urls"))
     return {
         title_prop: {"title":[{"type":"text","text":{"content": title_text}}]},
         "Procurement Method": ms(rec.get("procurement") or []),
         "Oracle Name": rt(rec.get("oracle_raw","")),
         "FF Name": rt(rec.get("ff_raw","")),
         "CN Sort": num(rec.get("cn_sort")),
+        "Image": {"files": files},
     }
 
 def ensure_db(notion: NotionClient, parent_id: str, title: str):
@@ -116,14 +118,14 @@ with tab:
                         existing = notion.query_by_card_id(db["id"], rec["id"])
                         if existing:
                             if update_existing:
-                                notion.update_card_minimal(existing["id"], props_update(title_prop, new_title, rec))
+                                notion.update_card_minimal(existing["id"], props_update(notion, title_prop, new_title, rec))
                                 updated += 1
                                 if len(sample) < 10:
                                     sample.append(f'{u}-{rec.get("collector_number","?")}: → {new_title}')
                             else:
                                 skipped += 1
                         else:
-                            notion.create_card_page(db["id"], props_create(rec, title_prop, new_title))
+                            notion.create_card_page(db["id"], props_create(notion, rec, title_prop, new_title))
                             created += 1
                     except Exception as e:
                         failed += 1

--- a/mtg_importer/cli.py
+++ b/mtg_importer/cli.py
@@ -7,13 +7,13 @@ from .overrides import load_overrides, apply_overrides
 
 def _ts(): return time.strftime("[%Y-%m-%d %H:%M:%S]")
 
-def build_props_for_create(rec: dict, title_prop: str, title_text: str) -> Dict[str, Any]:
+def build_props_for_create(rec: dict, title_prop: str, title_text: str, notion: NotionClient) -> Dict[str, Any]:
     def rt(v): return {"rich_text":[{"type":"text","text":{"content":v}}]} if v else {"rich_text":[]}
     def sel(v): return {"select":{"name":v}} if v else {"select":None}
     def ms(vs): return {"multi_select":[{"name":x} for x in (vs or [])]}
     def num(n): return {"number": float(n) if n is not None else None}
     def url(v): return {"url": v or None}
-    files = [{"type":"external","name":"image","external":{"url":u}} for u in (rec.get("image_urls") or [])]
+    files = notion.upload_images(rec.get("image_urls"))
     return {
         title_prop: {"title":[{"type":"text","text":{"content": title_text}}]},
         "Set": sel(rec.get("set")),
@@ -37,16 +37,18 @@ def build_props_for_create(rec: dict, title_prop: str, title_text: str) -> Dict[
         "Image": {"files": files},
     }
 
-def build_props_for_update(title_prop: str, title_text: str, rec: dict) -> Dict[str, Any]:
+def build_props_for_update(title_prop: str, title_text: str, rec: dict, notion: NotionClient) -> Dict[str, Any]:
     def ms(vs): return {"multi_select":[{"name":x} for x in (vs or [])]}
     def rt(v): return {"rich_text":[{"type":"text","text":{"content":v}}]} if v else {"rich_text":[]}
     def num(n): return {"number": float(n) if n is not None else None}
+    files = notion.upload_images(rec.get("image_urls"))
     return {
         title_prop: {"title":[{"type":"text","text":{"content": title_text}}]},
         "Procurement Method": ms(rec.get("procurement") or []),
         "Oracle Name": rt(rec.get("oracle_raw","")),
         "FF Name": rt(rec.get("ff_raw","")),
         "CN Sort": num(rec.get("cn_sort")),
+        "Image": {"files": files},
     }
 
 def cmd_import(args):
@@ -91,7 +93,7 @@ def cmd_import(args):
                             previews.append(f'UPDATE {key}: "{title_text}" | methods={rec.get("procurement")}')
                         updated += 1
                     else:
-                        props = build_props_for_update(title_prop, title_text, rec)
+                        props = build_props_for_update(title_prop, title_text, rec, notion)
                         notion.update_card_minimal(existing["id"], props)
                         updated += 1
                 else:
@@ -100,7 +102,7 @@ def cmd_import(args):
                             previews.append(f'CREATE {key}: "{title_text}" | methods={rec.get("procurement")}')
                         created += 1
                     else:
-                        props = build_props_for_create(rec, title_prop, title_text)
+                        props = build_props_for_create(rec, title_prop, title_text, notion)
                         notion.create_card_page(db["id"], props)
                         created += 1
             except Exception as e:

--- a/mtg_importer/notion_api.py
+++ b/mtg_importer/notion_api.py
@@ -15,6 +15,29 @@ class NotionClient:
     def get_parent(self, page_id: str):
         return requests.get(f"{NOTION}/pages/{page_id}", headers=self.h, timeout=30)
 
+    def upload_images(self, urls: List[str]) -> List[Dict[str, Any]]:
+        """Download each image URL and upload it to Notion as a file.
+
+        Returns a list of Notion file objects suitable for the "files" property."""
+        files: List[Dict[str, Any]] = []
+        for idx, url in enumerate(urls or []):
+            try:
+                resp = requests.get(url, timeout=60)
+                resp.raise_for_status()
+                name = f"image_{idx}.jpg"
+                up_headers = {k: v for k, v in self.h.items() if k != "Content-Type"}
+                upload = requests.post(f"{NOTION}/files", headers=up_headers, files={"file": (name, resp.content)}, timeout=60)
+                upload.raise_for_status()
+                info = upload.json().get("file", {})
+                files.append({
+                    "type": "file",
+                    "name": info.get("name", name),
+                    "file": {"url": info.get("url"), "expiry_time": info.get("expiry_time")}
+                })
+            except Exception:
+                continue
+        return files
+
     def search_db_by_title(self, title: str) -> Optional[Dict[str, Any]]:
         body = {"query": title, "filter": {"property": "object", "value": "database"}}
         r = requests.post(f"{NOTION}/search", headers=self.h, data=json.dumps(body), timeout=60); r.raise_for_status()

--- a/notion_api.py
+++ b/notion_api.py
@@ -15,6 +15,29 @@ class NotionClient:
     def get_parent(self, page_id: str):
         return requests.get(f"{NOTION}/pages/{page_id}", headers=self.h, timeout=30)
 
+    def upload_images(self, urls: List[str]) -> List[Dict[str, Any]]:
+        """Download each image URL and upload it to Notion as a file.
+
+        Returns a list of Notion file objects suitable for the "files" property."""
+        files: List[Dict[str, Any]] = []
+        for idx, url in enumerate(urls or []):
+            try:
+                resp = requests.get(url, timeout=60)
+                resp.raise_for_status()
+                name = f"image_{idx}.jpg"
+                up_headers = {k: v for k, v in self.h.items() if k != "Content-Type"}
+                upload = requests.post(f"{NOTION}/files", headers=up_headers, files={"file": (name, resp.content)}, timeout=60)
+                upload.raise_for_status()
+                info = upload.json().get("file", {})
+                files.append({
+                    "type": "file",
+                    "name": info.get("name", name),
+                    "file": {"url": info.get("url"), "expiry_time": info.get("expiry_time")}
+                })
+            except Exception:
+                continue
+        return files
+
     def search_db_by_title(self, title: str) -> Optional[Dict[str, Any]]:
         body = {"query": title, "filter": {"property": "object", "value": "database"}}
         r = requests.post(f"{NOTION}/search", headers=self.h, data=json.dumps(body), timeout=60); r.raise_for_status()


### PR DESCRIPTION
## Summary
- add `upload_images` helper to fetch Scryfall art and upload to Notion file storage
- create/update card builders now attach uploaded images, ensuring existing pages refresh their images

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c4893fde388332a0c9f3accbc63ce8