### PR TITLE
feat: add interactive single-card import

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,21 @@ cd "<the folder you unzipped>"
 chmod +x "Run MTG Notion Importer.command"
 ./"Run MTG Notion Importer.command"
 ```
+
+## Add individual cards
+You can insert a single card into your Notion database from the web app or the terminal.
+
+### Web app
+Run `streamlit run mtg_importer/app.py` and open the **Add single card** tab.
+Search for a card name (optionally restricting to a set), preview the prints and
+their images, then insert the selected print into your database.
+
+### Command line
+```bash
+python -m mtg_importer.cli add-card "Black Lotus" --db-title "MTG – Cards" --parent <PAGE_ID> --token <NOTION_TOKEN>
+```
+
+The CLI searches Scryfall for matching prints and displays a numbered preview
+with the set code, collector number, rarity and image URL. Choose the desired
+print and confirm to create the page. Use `--dry-run` to preview without writing
+to Notion.

--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ You can insert a single card into your Notion database from the web app or the t
 
 ### Web app
 Run `streamlit run mtg_importer/app.py` and open the **Add single card** tab.
-Search for a card name (optionally restricting to a set), preview the prints and
-their images, then insert the selected print into your database.
+Search for a card name (optionally restricting to a set) to preview all matching
+prints and their images. Tick the prints you want, then enter your Notion token,
+parent page and database title to batch-add the selected cards.
 
 ### Command line
 ```bash

--- a/app.py
+++ b/app.py
@@ -9,7 +9,7 @@ from typing import Dict, Any
 import json
 
 from mtg_importer.notion_api import NotionClient
-from mtg_importer.scry import fetch_set, normalize
+from mtg_importer.scry import fetch_set, normalize, search_prints
 from mtg_importer.util import format_title
 
 st.set_page_config(page_title="MTG Notion Importer", page_icon="🗂️", layout="centered")
@@ -101,9 +101,9 @@ def verify(notion: NotionClient, parent: str) -> bool:
         st.error(f"Failed to open parent page: {r.status_code} {r.text}"); return False
     return True
 
-# UI
-tab = st.container()
-with tab:
+tab_sets, tab_single = st.tabs(["Import sets", "Add single card"])
+
+with tab_sets:
     st.subheader("Import sets (UPSERT)")
     with st.form("run_sets_form"):
         token = st.text_input("Notion API token", type="password", help="ntn_*")
@@ -161,3 +161,51 @@ with tab:
                 st.warning("Some items failed; see preview list above.")
             st.success(f"Totals — created={total_created} updated={total_updated} skipped={total_skipped} failed={total_failed}")
             st.info(f"Database: {db.get('url')}")
+
+with tab_single:
+    st.subheader("Add single card")
+    with st.form("search_card_form"):
+        s_token = st.text_input("Notion API token", type="password", value=st.session_state.get("s_token", ""), help="ntn_*")
+        s_parent = st.text_input("Parent page ID", value=st.session_state.get("s_parent", "250e0945-9e39-80fc-a408-c7d09ab28763"))
+        s_db = st.text_input("Database title", value=st.session_state.get("s_db", "MTG – Cards"))
+        card_name = st.text_input("Card name", value=st.session_state.get("card_name", ""))
+        card_set = st.text_input("Set code (optional)", value=st.session_state.get("card_set", ""))
+        s_title_style = st.selectbox("Title style", ["Oracle — FF","FF — Oracle","Oracle only"], index=0)
+        search_submitted = st.form_submit_button("Search prints")
+
+    if search_submitted:
+        st.session_state["s_token"] = s_token
+        st.session_state["s_parent"] = s_parent
+        st.session_state["s_db"] = s_db
+        st.session_state["card_name"] = card_name
+        st.session_state["card_set"] = card_set
+        st.session_state["s_title_style"] = s_title_style
+        notion = NotionClient(s_token)
+        if verify(notion, s_parent):
+            db = ensure_db(notion, s_parent, s_db)
+            st.session_state["s_db_id"] = db["id"]
+            st.session_state["s_title_prop"] = notion.get_title_property_name(db["id"])
+            prints = [normalize(p) for p in search_prints(card_name, card_set or None)]
+            st.session_state["prints"] = prints
+
+    prints = st.session_state.get("prints")
+    if prints:
+        options = [f"{rec.get('set')} #{rec.get('collector_number')} {rec.get('rarity')}" for rec in prints]
+        choice = st.selectbox("Choose a print", list(range(len(prints))), format_func=lambda i: options[i])
+        img = (prints[choice].get("image_urls") or [""])[0]
+        if img:
+            st.image(img)
+        if st.button("Add card to Notion"):
+            notion = NotionClient(st.session_state.get("s_token"))
+            db_id = st.session_state.get("s_db_id")
+            title_prop = st.session_state.get("s_title_prop")
+            rec = prints[choice]
+            existing = notion.query_by_card_id(db_id, rec["id"])
+            if existing:
+                st.warning("Card already exists in database")
+            else:
+                title_text = format_title(rec.get("oracle_raw",""), rec.get("ff_raw",""), st.session_state.get("s_title_style", "Oracle — FF"))
+                props = props_create(notion, rec, title_prop, title_text)
+                notion.create_card_page(db_id, props)
+                st.success(f"Added {title_text}")
+                del st.session_state["prints"]

--- a/app.py
+++ b/app.py
@@ -163,49 +163,64 @@ with tab_sets:
             st.info(f"Database: {db.get('url')}")
 
 with tab_single:
-    st.subheader("Add single card")
+    st.subheader("Add cards by search")
+    # --- Part 1: search Scryfall ---
     with st.form("search_card_form"):
-        s_token = st.text_input("Notion API token", type="password", value=st.session_state.get("s_token", ""), help="ntn_*")
-        s_parent = st.text_input("Parent page ID", value=st.session_state.get("s_parent", "250e0945-9e39-80fc-a408-c7d09ab28763"))
-        s_db = st.text_input("Database title", value=st.session_state.get("s_db", "MTG – Cards"))
         card_name = st.text_input("Card name", value=st.session_state.get("card_name", ""))
         card_set = st.text_input("Set code (optional)", value=st.session_state.get("card_set", ""))
-        s_title_style = st.selectbox("Title style", ["Oracle — FF","FF — Oracle","Oracle only"], index=0)
         search_submitted = st.form_submit_button("Search prints")
 
     if search_submitted:
-        st.session_state["s_token"] = s_token
-        st.session_state["s_parent"] = s_parent
-        st.session_state["s_db"] = s_db
         st.session_state["card_name"] = card_name
         st.session_state["card_set"] = card_set
-        st.session_state["s_title_style"] = s_title_style
-        notion = NotionClient(s_token)
-        if verify(notion, s_parent):
-            db = ensure_db(notion, s_parent, s_db)
-            st.session_state["s_db_id"] = db["id"]
-            st.session_state["s_title_prop"] = notion.get_title_property_name(db["id"])
-            prints = [normalize(p) for p in search_prints(card_name, card_set or None)]
-            st.session_state["prints"] = prints
+        prints = [normalize(p) for p in search_prints(card_name, card_set or None)]
+        st.session_state["prints"] = prints
+        # clear previous selections
+        for rec in prints:
+            st.session_state.pop(f"sel_{rec['id']}", None)
 
     prints = st.session_state.get("prints")
     if prints:
-        options = [f"{rec.get('set')} #{rec.get('collector_number')} {rec.get('rarity')}" for rec in prints]
-        choice = st.selectbox("Choose a print", list(range(len(prints))), format_func=lambda i: options[i])
-        img = (prints[choice].get("image_urls") or [""])[0]
-        if img:
-            st.image(img)
-        if st.button("Add card to Notion"):
-            notion = NotionClient(st.session_state.get("s_token"))
-            db_id = st.session_state.get("s_db_id")
-            title_prop = st.session_state.get("s_title_prop")
-            rec = prints[choice]
-            existing = notion.query_by_card_id(db_id, rec["id"])
-            if existing:
-                st.warning("Card already exists in database")
-            else:
-                title_text = format_title(rec.get("oracle_raw",""), rec.get("ff_raw",""), st.session_state.get("s_title_style", "Oracle — FF"))
-                props = props_create(notion, rec, title_prop, title_text)
-                notion.create_card_page(db_id, props)
-                st.success(f"Added {title_text}")
-                del st.session_state["prints"]
+        st.write("Select one or more prints to add:")
+        cols = st.columns(3)
+        for idx, rec in enumerate(prints):
+            col = cols[idx % 3]
+            with col:
+                img = (rec.get("image_urls") or [""])[0]
+                if img:
+                    st.image(img, use_column_width=True)
+                st.checkbox(f"{rec.get('set')} #{rec.get('collector_number')} {rec.get('rarity')}", key=f"sel_{rec['id']}")
+
+        selected = [rec for rec in prints if st.session_state.get(f"sel_{rec['id']}")]
+        if selected:
+            # --- Part 2: Notion credentials and batch add ---
+            with st.form("add_selected_form"):
+                s_token = st.text_input("Notion API token", type="password", value=st.session_state.get("s_token", ""), help="ntn_*")
+                s_parent = st.text_input("Parent page ID", value=st.session_state.get("s_parent", "250e0945-9e39-80fc-a408-c7d09ab28763"))
+                s_db = st.text_input("Database title", value=st.session_state.get("s_db", "MTG – Cards"))
+                s_title_style = st.selectbox("Title style", ["Oracle — FF","FF — Oracle","Oracle only"], index=0)
+                add_submitted = st.form_submit_button(f"Add {len(selected)} card(s) to Notion")
+
+            if add_submitted:
+                st.session_state["s_token"] = s_token
+                st.session_state["s_parent"] = s_parent
+                st.session_state["s_db"] = s_db
+                notion = NotionClient(s_token)
+                if verify(notion, s_parent):
+                    db = ensure_db(notion, s_parent, s_db)
+                    title_prop = notion.get_title_property_name(db["id"])
+                    added = skipped = 0
+                    for rec in selected:
+                        existing = notion.query_by_card_id(db["id"], rec["id"])
+                        if existing:
+                            skipped += 1
+                            continue
+                        title_text = format_title(rec.get("oracle_raw",""), rec.get("ff_raw",""), s_title_style)
+                        props = props_create(notion, rec, title_prop, title_text)
+                        notion.create_card_page(db["id"], props)
+                        added += 1
+                    st.success(f"Added {added} card(s); skipped {skipped} existing")
+                    # reset state after adding
+                    del st.session_state["prints"]
+                    for rec in selected:
+                        st.session_state.pop(f"sel_{rec['id']}", None)

--- a/mtg_importer/app.py
+++ b/mtg_importer/app.py
@@ -9,7 +9,7 @@ from typing import Dict, Any
 import json
 
 from mtg_importer.notion_api import NotionClient
-from mtg_importer.scry import fetch_set, normalize
+from mtg_importer.scry import fetch_set, normalize, search_prints
 from mtg_importer.util import format_title
 
 st.set_page_config(page_title="MTG Notion Importer", page_icon="🗂️", layout="centered")
@@ -101,9 +101,9 @@ def verify(notion: NotionClient, parent: str) -> bool:
         st.error(f"Failed to open parent page: {r.status_code} {r.text}"); return False
     return True
 
-# UI
-tab = st.container()
-with tab:
+tab_sets, tab_single = st.tabs(["Import sets", "Add single card"])
+
+with tab_sets:
     st.subheader("Import sets (UPSERT)")
     with st.form("run_sets_form"):
         token = st.text_input("Notion API token", type="password", help="ntn_*")
@@ -161,3 +161,51 @@ with tab:
                 st.warning("Some items failed; see preview list above.")
             st.success(f"Totals — created={total_created} updated={total_updated} skipped={total_skipped} failed={total_failed}")
             st.info(f"Database: {db.get('url')}")
+
+with tab_single:
+    st.subheader("Add single card")
+    with st.form("search_card_form"):
+        s_token = st.text_input("Notion API token", type="password", value=st.session_state.get("s_token", ""), help="ntn_*")
+        s_parent = st.text_input("Parent page ID", value=st.session_state.get("s_parent", "250e0945-9e39-80fc-a408-c7d09ab28763"))
+        s_db = st.text_input("Database title", value=st.session_state.get("s_db", "MTG – Cards"))
+        card_name = st.text_input("Card name", value=st.session_state.get("card_name", ""))
+        card_set = st.text_input("Set code (optional)", value=st.session_state.get("card_set", ""))
+        s_title_style = st.selectbox("Title style", ["Oracle — FF","FF — Oracle","Oracle only"], index=0)
+        search_submitted = st.form_submit_button("Search prints")
+
+    if search_submitted:
+        st.session_state["s_token"] = s_token
+        st.session_state["s_parent"] = s_parent
+        st.session_state["s_db"] = s_db
+        st.session_state["card_name"] = card_name
+        st.session_state["card_set"] = card_set
+        st.session_state["s_title_style"] = s_title_style
+        notion = NotionClient(s_token)
+        if verify(notion, s_parent):
+            db = ensure_db(notion, s_parent, s_db)
+            st.session_state["s_db_id"] = db["id"]
+            st.session_state["s_title_prop"] = notion.get_title_property_name(db["id"])
+            prints = [normalize(p) for p in search_prints(card_name, card_set or None)]
+            st.session_state["prints"] = prints
+
+    prints = st.session_state.get("prints")
+    if prints:
+        options = [f"{rec.get('set')} #{rec.get('collector_number')} {rec.get('rarity')}" for rec in prints]
+        choice = st.selectbox("Choose a print", list(range(len(prints))), format_func=lambda i: options[i])
+        img = (prints[choice].get("image_urls") or [""])[0]
+        if img:
+            st.image(img)
+        if st.button("Add card to Notion"):
+            notion = NotionClient(st.session_state.get("s_token"))
+            db_id = st.session_state.get("s_db_id")
+            title_prop = st.session_state.get("s_title_prop")
+            rec = prints[choice]
+            existing = notion.query_by_card_id(db_id, rec["id"])
+            if existing:
+                st.warning("Card already exists in database")
+            else:
+                title_text = format_title(rec.get("oracle_raw",""), rec.get("ff_raw",""), st.session_state.get("s_title_style", "Oracle — FF"))
+                props = props_create(notion, rec, title_prop, title_text)
+                notion.create_card_page(db_id, props)
+                st.success(f"Added {title_text}")
+                del st.session_state["prints"]

--- a/mtg_importer/app.py
+++ b/mtg_importer/app.py
@@ -163,49 +163,64 @@ with tab_sets:
             st.info(f"Database: {db.get('url')}")
 
 with tab_single:
-    st.subheader("Add single card")
+    st.subheader("Add cards by search")
+    # --- Part 1: search Scryfall ---
     with st.form("search_card_form"):
-        s_token = st.text_input("Notion API token", type="password", value=st.session_state.get("s_token", ""), help="ntn_*")
-        s_parent = st.text_input("Parent page ID", value=st.session_state.get("s_parent", "250e0945-9e39-80fc-a408-c7d09ab28763"))
-        s_db = st.text_input("Database title", value=st.session_state.get("s_db", "MTG – Cards"))
         card_name = st.text_input("Card name", value=st.session_state.get("card_name", ""))
         card_set = st.text_input("Set code (optional)", value=st.session_state.get("card_set", ""))
-        s_title_style = st.selectbox("Title style", ["Oracle — FF","FF — Oracle","Oracle only"], index=0)
         search_submitted = st.form_submit_button("Search prints")
 
     if search_submitted:
-        st.session_state["s_token"] = s_token
-        st.session_state["s_parent"] = s_parent
-        st.session_state["s_db"] = s_db
         st.session_state["card_name"] = card_name
         st.session_state["card_set"] = card_set
-        st.session_state["s_title_style"] = s_title_style
-        notion = NotionClient(s_token)
-        if verify(notion, s_parent):
-            db = ensure_db(notion, s_parent, s_db)
-            st.session_state["s_db_id"] = db["id"]
-            st.session_state["s_title_prop"] = notion.get_title_property_name(db["id"])
-            prints = [normalize(p) for p in search_prints(card_name, card_set or None)]
-            st.session_state["prints"] = prints
+        prints = [normalize(p) for p in search_prints(card_name, card_set or None)]
+        st.session_state["prints"] = prints
+        # clear previous selections
+        for rec in prints:
+            st.session_state.pop(f"sel_{rec['id']}", None)
 
     prints = st.session_state.get("prints")
     if prints:
-        options = [f"{rec.get('set')} #{rec.get('collector_number')} {rec.get('rarity')}" for rec in prints]
-        choice = st.selectbox("Choose a print", list(range(len(prints))), format_func=lambda i: options[i])
-        img = (prints[choice].get("image_urls") or [""])[0]
-        if img:
-            st.image(img)
-        if st.button("Add card to Notion"):
-            notion = NotionClient(st.session_state.get("s_token"))
-            db_id = st.session_state.get("s_db_id")
-            title_prop = st.session_state.get("s_title_prop")
-            rec = prints[choice]
-            existing = notion.query_by_card_id(db_id, rec["id"])
-            if existing:
-                st.warning("Card already exists in database")
-            else:
-                title_text = format_title(rec.get("oracle_raw",""), rec.get("ff_raw",""), st.session_state.get("s_title_style", "Oracle — FF"))
-                props = props_create(notion, rec, title_prop, title_text)
-                notion.create_card_page(db_id, props)
-                st.success(f"Added {title_text}")
-                del st.session_state["prints"]
+        st.write("Select one or more prints to add:")
+        cols = st.columns(3)
+        for idx, rec in enumerate(prints):
+            col = cols[idx % 3]
+            with col:
+                img = (rec.get("image_urls") or [""])[0]
+                if img:
+                    st.image(img, use_column_width=True)
+                st.checkbox(f"{rec.get('set')} #{rec.get('collector_number')} {rec.get('rarity')}", key=f"sel_{rec['id']}")
+
+        selected = [rec for rec in prints if st.session_state.get(f"sel_{rec['id']}")]
+        if selected:
+            # --- Part 2: Notion credentials and batch add ---
+            with st.form("add_selected_form"):
+                s_token = st.text_input("Notion API token", type="password", value=st.session_state.get("s_token", ""), help="ntn_*")
+                s_parent = st.text_input("Parent page ID", value=st.session_state.get("s_parent", "250e0945-9e39-80fc-a408-c7d09ab28763"))
+                s_db = st.text_input("Database title", value=st.session_state.get("s_db", "MTG – Cards"))
+                s_title_style = st.selectbox("Title style", ["Oracle — FF","FF — Oracle","Oracle only"], index=0)
+                add_submitted = st.form_submit_button(f"Add {len(selected)} card(s) to Notion")
+
+            if add_submitted:
+                st.session_state["s_token"] = s_token
+                st.session_state["s_parent"] = s_parent
+                st.session_state["s_db"] = s_db
+                notion = NotionClient(s_token)
+                if verify(notion, s_parent):
+                    db = ensure_db(notion, s_parent, s_db)
+                    title_prop = notion.get_title_property_name(db["id"])
+                    added = skipped = 0
+                    for rec in selected:
+                        existing = notion.query_by_card_id(db["id"], rec["id"])
+                        if existing:
+                            skipped += 1
+                            continue
+                        title_text = format_title(rec.get("oracle_raw",""), rec.get("ff_raw",""), s_title_style)
+                        props = props_create(notion, rec, title_prop, title_text)
+                        notion.create_card_page(db["id"], props)
+                        added += 1
+                    st.success(f"Added {added} card(s); skipped {skipped} existing")
+                    # reset state after adding
+                    del st.session_state["prints"]
+                    for rec in selected:
+                        st.session_state.pop(f"sel_{rec['id']}", None)

--- a/tests/test_add_card_cli.py
+++ b/tests/test_add_card_cli.py
@@ -1,0 +1,57 @@
+import argparse, builtins
+from types import SimpleNamespace
+from mtg_importer import cli
+
+class DummyNotion:
+    def __init__(self, token):
+        self.created = None
+    def verify_token(self):
+        return True
+    def get_parent(self, page_id):
+        return SimpleNamespace(status_code=200)
+    def search_db_by_title(self, title):
+        return {"id": "db"}
+    def create_database(self, parent, title):
+        return {"id": "db"}
+    def ensure_columns(self, db_id):
+        pass
+    def get_title_property_name(self, db_id):
+        return "Name"
+    def query_by_card_id(self, db_id, card_id):
+        return None
+    def create_card_page(self, db_id, props):
+        self.created = props
+    def upload_images(self, urls):
+        return []
+
+
+def _cards():
+    return [
+        {"name": "Card A", "set": "aaa", "collector_number": "1", "rarity": "common", "id": "id1", "oracle_id": "oid1", "image_uris": {"normal": "u1"}, "promo_types": [], "lang": "en"},
+        {"name": "Card A", "set": "bbb", "collector_number": "2", "rarity": "rare", "id": "id2", "oracle_id": "oid2", "image_uris": {"normal": "u2"}, "promo_types": [], "lang": "en"},
+    ]
+
+
+def test_add_card_creates_selected_print(monkeypatch):
+    cards = _cards()
+    monkeypatch.setattr(cli, "search_prints", lambda name, setcode=None: cards)
+    dummy = DummyNotion("tok")
+    monkeypatch.setattr(cli, "NotionClient", lambda token: dummy)
+    inputs = iter(["2", "y"])
+    monkeypatch.setattr(builtins, "input", lambda _: next(inputs))
+    args = argparse.Namespace(name="Card A", set=None, db_title="DB", parent="p", token="tok", dry_run=False)
+    cli.cmd_add_card(args)
+    assert dummy.created is not None
+    assert dummy.created["Card ID"]["rich_text"][0]["text"]["content"] == "id2"
+
+
+def test_add_card_cancel(monkeypatch):
+    cards = _cards()
+    monkeypatch.setattr(cli, "search_prints", lambda name, setcode=None: cards)
+    dummy = DummyNotion("tok")
+    monkeypatch.setattr(cli, "NotionClient", lambda token: dummy)
+    inputs = iter([""])
+    monkeypatch.setattr(builtins, "input", lambda _: next(inputs, ""))
+    args = argparse.Namespace(name="Card A", set=None, db_title="DB", parent="p", token="tok", dry_run=False)
+    cli.cmd_add_card(args)
+    assert dummy.created is None


### PR DESCRIPTION
## Summary
- allow searching and previewing individual card prints before adding to Notion from both CLI and web app
- expose new `add-card` CLI subcommand and web tab
- document interactive card selection usage

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4de4edff88332ae1cfcb0f2cda41c